### PR TITLE
🚨 Add GitHub Skills Activity (Fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Fixes Critical Missing Activity: GitHub Skills

This pull request addresses **Issue #6** - the time-sensitive missing GitHub Skills activity that was announced by the principal.

### 📋 Changes Made
- ✅ Added "GitHub Skills" to the activities dictionary
- ✅ Included reference to GitHub Certifications program (as mentioned in the original announcement)
- ✅ Set appropriate schedule: Mondays, 3:30 PM - 4:30 PM  
- ✅ Set capacity to 25 students to accommodate high interest
- ✅ Ready for immediate student registration

### 🎯 Issue Resolution
- **Addresses**: #6 (🚨 Missing Activity: GitHub Skills)
- **Priority**: High (time-sensitive with deadline this week)
- **Reporter**: Hewbie C., 11th Grade Student

### ⏰ Timeline Impact
This resolves the urgent timeline mentioned in the issue - students can now register before the deadline at the end of this week.

### 🧪 Testing
- [x] Activity appears in the activities list
- [x] Students can sign up for the activity
- [x] Capacity limits are enforced
- [x] Schedule information is displayed correctly

**Ready for immediate merge to meet the principal's announcement timeline!** 🚀